### PR TITLE
Replace 'EXAMPLE' in the AWS config with environment variables

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     aws.access_key_id = ENV['AWS_KEY_ID']
     aws.secret_access_key = ENV['AWS_SECRET_KEY']
     aws.keypair_name = ENV['AWS_KEYPAIR_NAME']
-    aws.security_groups = [ "default-vpn" ]
+    aws.security_groups = ENV['AWS_SECURITY_GROUP']
     aws.instance_type = "m1.small"
     aws.ami = "ami-e7582d8e"
     aws.tags = { Name: 'Vagrant alm' }


### PR DESCRIPTION
This change replaces the use of 'EXAMPLE' with references to appropriately named environment variables. I intentionally have not modified the other providers - digital ocean et al - although similar things could be done there as well.

An example of a bash script to set up the variables (these values are made up!):

```
$ cat ~/.awskeys
export AWS_KEY_ID="OIFUVB3SIT8GSNTKGSUT"
export AWS_SECRET_KEY="9CVjK7xVBIER8N9z8rvVrkw8nvO/EANO+nI&EFbL"
export AWS_KEYPAIR_NAME="noname"
export AWS_KEY_PATH="~/.ssh/id_rsa"
export AWS_SECURITY_GROUP="default"
```

and then use that using bash 'source' or bash/sh 'dot' syntax:

```
$ source ~/.awskeys
$ .  ~/.awskeys
```

Or just include them in your .bashrc or .profile files.
