### PR TITLE
The setting config.vm.boot_mode does not exist (any more)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,10 @@ Vagrant.configure("2") do |config|
   # Override settings for specific providers
   config.vm.provider :virtualbox do |vb, override|
     vb.name = "alm"
+
+    # Boot with a GUI so you can see the screen. (Default is headless)
     # vb.gui = true
+    
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
 
@@ -55,8 +58,6 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.hostname = "alm.local"
-
-  # Boot with a GUI so you can see the screen. (Default is headless)
 
   # Assign this VM to a host-only network IP, allowing you to access it
   # via the IP. Host-only networks can talk to the host machine as well as


### PR DESCRIPTION
There is an equivalent vb.gui setting for the Virtualbox provider. Possibly there is one for VMware but I am not familiar. AWS boxes don't have a GUI mode AFAIK... presumably neither do Digital Ocean ones for the same reason.
