### PR TITLE
The 'insttoken' for Scopus is also optional.

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -173,6 +173,7 @@ class Source < ActiveRecord::Base
       next if name == "crossref" && field == :password
       next if name == "mendeley" && field == :access_token
       next if name == "twitter_search" && field == :access_token
+      next if name == "scopus" && field == :insttoken
 
       errors.add(field, "can't be blank") if send(field).blank?
     end


### PR DESCRIPTION
"insttoken" is an optional feature of the API but the UI was requiring it. This change makes it optional in the UI.
