### PR TITLE
Set hostname from the [alm][hostname] setting; Upgrade openssh

### DIFF
--- a/vendor/cookbooks/alm/recipes/default.rb
+++ b/vendor/cookbooks/alm/recipes/default.rb
@@ -21,6 +21,23 @@ package 'openssl' do
   action :upgrade
 end
 
+# Upgrade openssh to latest version
+package 'openssh-server' do
+  action :upgrade
+end
+
+file '/etc/hostname' do
+  content "#{node[:alm][:hostname]}\n"
+end
+
+file '/etc/hosts' do
+  content "127.0.0.1  localhost #{node[:alm][:hostname]}\n::1 ip6-localhost ip6-loopback #{node[:alm][:hostname]}\nfe00::0 ip6-localnet\nff00::0 ip6-mcastprefix\nff02::1 ip6-allnodes\nff02::2 ip6-allrouters\nff02::3 ip6-allhosts\n"
+end
+
+service 'hostname' do
+  action :restart
+end
+
 # Install required packages
 %w{libxml2-dev libxslt-dev ruby2.1 ruby2.1-dev curl}.each do |pkg|
   package pkg do


### PR DESCRIPTION
This helps with the networking code, so that requests use the loopback interface properly. Especially on AWS, couchdb references that go via the external interface will fail unless couchdb external access is public also, because of the firewall.

Opportunity taken to ensure openssh is up to date as well as openssl.
