### PR TITLE
Use Zenodo gem 0.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "uglifier", "~> 2.5.3"
 gem 'coffee-rails', '~> 4.1.0'
 gem "ember-cli-rails"
 
-gem "zenodo", :git => "https://github.com/zdennis/zenodo.git"
+gem "zenodo", "~> 0.0.8"
 
 group :development do
   gem 'pry-rails', '~> 0.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/fly1tkg/state_machine.git
-  revision: 181f758a50698c4564b46a48d5704b48e9b3cf33
-  branch: issue/334
-  specs:
-    state_machine (1.2.0)
-
-GIT
   remote: https://github.com/mfenner/omniauth-orcid.git
   revision: 31859733280f3523f716bafec5e17575cecf5d51
   specs:
@@ -14,13 +7,11 @@ GIT
       omniauth-oauth2 (~> 1.1)
 
 GIT
-  remote: https://github.com/zdennis/zenodo.git
-  revision: fd60a0b48f40a94ba29839f3f4bee21144a31b47
+  remote: https://github.com/fly1tkg/state_machine.git
+  revision: 181f758a50698c4564b46a48d5704b48e9b3cf33
+  branch: issue/334
   specs:
-    zenodo (0.0.7)
-      activesupport (~> 4.1)
-      faraday (~> 0.9)
-      mime-types (~> 2.6)
+    state_machine (1.2.0)
 
 GEM
   remote: http://rubygems.org/
@@ -424,6 +415,10 @@ GEM
     with_env (1.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zenodo (0.0.8)
+      activesupport (~> 4.1)
+      faraday (~> 0.9)
+      mime-types (~> 2.6)
 
 PLATFORMS
   ruby
@@ -511,7 +506,4 @@ DEPENDENCIES
   will_paginate (= 3.0.7)
   will_paginate-bootstrap (~> 1.0.1)
   with_env (~> 1.1.0)
-  zenodo!
-
-BUNDLED WITH
-   1.10.5
+  zenodo (~> 0.0.8)


### PR DESCRIPTION
The Zenodo ruby gem is now Ruby 2.0.x compatible. This is to no longer use my fork, but the official gem.

Reference: https://github.com/sprotocols/zenodo/pull/7