### PR TITLE
use 5-1-unstable branch for AMi we build with DataCite

### DIFF
--- a/template.json
+++ b/template.json
@@ -56,7 +56,7 @@
   "variables": {
     "compression_level": "6",
     "mirror": "http://releases.ubuntu.com",
-    "git_branch": "5-0-unstable",
+    "git_branch": "5-1-unstable",
     "chef_version": "12.5.1",
     "access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",


### PR DESCRIPTION
value is still hard-coded. Mostly a test of new pull request workflow.
