### PR TITLE
setting the host header in network calls doesn't work for redirects.

### DIFF
--- a/app/models/concerns/networkable.rb
+++ b/app/models/concerns/networkable.rb
@@ -37,7 +37,10 @@ module Networkable
 
     def set_request_headers(url, options)
       options[:headers] ||= {}
-      options[:headers]['Host'] = URI.parse(url).host
+
+      if options[:host]
+        options[:headers]['Host'] = URI.parse(url).host
+      end
 
       if options[:content_type].present?
         accept_headers = { "html" => 'text/html; charset=UTF-8',

--- a/app/models/concerns/resolvable.rb
+++ b/app/models/concerns/resolvable.rb
@@ -155,7 +155,7 @@ module Resolvable
       return {} if doi.blank?
 
       url = "https://api.crossref.org/works/" + PostRank::URI.escape(doi)
-      response = get_result(url, options)
+      response = get_result(url, options.merge(host: true))
 
       metadata = response.fetch("message", {})
       return { error: 'Resource not found.', status: 404 } if metadata.blank?
@@ -373,7 +373,7 @@ module Resolvable
       return prefix.registration_agency if prefix.present?
 
       url = "http://doi.crossref.org/doiRA/#{doi}"
-      response = get_result(url, options)
+      response = get_result(url, options.merge(host: true))
 
       ra = response.first.fetch("RA", nil)
       if ra.present?


### PR DESCRIPTION
This should fix at least some of the problems we have with lookup of the canonical URL. `Host` header was introduced since the Crossref REST API needs it. We should set this option specifically when we need it, not as the default.
