### PR TITLE
rename sources to crossref_datacite and datacite_crossref

### DIFF
--- a/app/models/agents/datacite_related.rb
+++ b/app/models/agents/datacite_related.rb
@@ -52,7 +52,10 @@ class DataciteRelated < Agent
 
     Array(items).map do |item|
       raw_relation_type, _related_identifier_type, related_identifier = item.split(':', 3)
-      pid = doi_as_url(related_identifier.strip.upcase)
+      doi = related_identifier.strip.upcase
+      registration_agency = get_doi_ra(doi)
+      _source_id = registration_agency == "crossref" ? "datacite_crossref" : "datacite_related"
+      pid = doi_as_url(doi)
 
       # find relation_type, default to "is_referenced_by" otherwise
       relation_type = cached_relation_type(raw_relation_type.underscore)
@@ -62,7 +65,7 @@ class DataciteRelated < Agent
         relation: { "subj_id" => subj["pid"],
                     "obj_id" => pid,
                     "relation_type_id" => relation_type_id,
-                    "source_id" => source_id,
+                    "source_id" => _source_id,
                     "publisher_id" => subj["publisher_id"] },
         subj: subj }
     end

--- a/db/seeds/development/sources.yml
+++ b/db/seeds/development/sources.yml
@@ -67,10 +67,15 @@ records:
     title: OpenEdition
     description: OpenEdition is the umbrella portal for OpenEdition Books, Revues.org, Hypotheses and Calenda in the humanities and social sciences.
     group_id: <%= sprig_record(Group, "relations").id %>
-  - sprig_id: crossref_related
-    name: crossref_related
+  - sprig_id: crossref_datacite
+    name: crossref_datacite
     title: CrossRef (DataCite)
     description: Import works linked to a DataCite DOI from CrossRef.
+    group_id: <%= sprig_record(Group, "relations").id %>
+  - sprig_id: datacite_crossref
+    name: datacite_crossref
+    title: DataCite (Crossref)
+    description: Import works with Crossref DOIs as relatedIdentifier via the DataCite Solr API.
     group_id: <%= sprig_record(Group, "relations").id %>
   - sprig_id: datacite_related
     name: datacite_related

--- a/db/seeds/production/sources.yml
+++ b/db/seeds/production/sources.yml
@@ -67,10 +67,15 @@ records:
     title: OpenEdition
     description: OpenEdition is the umbrella portal for OpenEdition Books, Revues.org, Hypotheses and Calenda in the humanities and social sciences.
     group_id: <%= sprig_record(Group, "relations").id %>
-  - sprig_id: crossref_related
-    name: crossref_related
+  - sprig_id: crossref_datacite
+    name: crossref_datacite
     title: CrossRef (DataCite)
     description: Import works linked to a DataCite DOI from CrossRef.
+    group_id: <%= sprig_record(Group, "relations").id %>
+  - sprig_id: datacite_crossref
+    name: datacite_crossref
+    title: DataCite (Crossref)
+    description: Import works with Crossref DOIs as relatedIdentifier via the DataCite Solr API.
     group_id: <%= sprig_record(Group, "relations").id %>
   - sprig_id: datacite_related
     name: datacite_related

--- a/db/seeds/stage/sources.yml
+++ b/db/seeds/stage/sources.yml
@@ -67,10 +67,15 @@ records:
     title: OpenEdition
     description: OpenEdition is the umbrella portal for OpenEdition Books, Revues.org, Hypotheses and Calenda in the humanities and social sciences.
     group_id: <%= sprig_record(Group, "relations").id %>
-  - sprig_id: crossref_related
-    name: crossref_related
+  - sprig_id: crossref_datacite
+    name: crossref_datacite
     title: CrossRef (DataCite)
     description: Import works linked to a DataCite DOI from CrossRef.
+    group_id: <%= sprig_record(Group, "relations").id %>
+  - sprig_id: datacite_crossref
+    name: datacite_crossref
+    title: DataCite (Crossref)
+    description: Import works with Crossref DOIs as relatedIdentifier via the DataCite Solr API.
     group_id: <%= sprig_record(Group, "relations").id %>
   - sprig_id: datacite_related
     name: datacite_related

--- a/docs/crossref_datacite.md
+++ b/docs/crossref_datacite.md
@@ -1,0 +1,6 @@
+---
+layout: card
+title: "Crossref (DataCite)"
+---
+
+Import works with DataCite DOI in the Crossref metadata.

--- a/docs/datacite_crossref.md
+++ b/docs/datacite_crossref.md
@@ -1,0 +1,6 @@
+---
+layout: card
+title: "DataCite (Crossref)"
+---
+
+Import works with Crossref DOI as relatedIdentifier via the DataCite Solr API.

--- a/spec/fixtures/vcr_cassettes/DataciteRelated/parse_data/should_report_if_there_are_works_returned_by_the_Datacite_Metadata_Search_API.yml
+++ b/spec/fixtures/vcr_cassettes/DataciteRelated/parse_data/should_report_if_there_are_works_returned_by_the_Datacite_Metadata_Search_API.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://doi.crossref.org/doiRA/10.5061/DRYAD.47SD5/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Lagotto - http://lagotto.local
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '60'
+      Date:
+      - Fri, 15 Apr 2016 13:13:11 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        [
+         {
+         "DOI": "10.5061/DRYAD.47SD5/1",
+         "RA": "Data Cite"
+        }
+        ]
+    http_version: 
+  recorded_at: Fri, 15 Apr 2016 13:13:12 GMT
+- request:
+    method: get
+    uri: http://doi.crossref.org/doiRA/10.1111/MEC.12069
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Lagotto - http://lagotto.local
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '55'
+      Date:
+      - Fri, 15 Apr 2016 13:13:11 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        [
+         {
+         "DOI": "10.1111/MEC.12069",
+         "RA": "CrossRef"
+        }
+        ]
+    http_version: 
+  recorded_at: Fri, 15 Apr 2016 13:13:12 GMT
+- request:
+    method: get
+    uri: http://doi.crossref.org/doiRA/10.1002/ECE3.563
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Lagotto - http://lagotto.local
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '54'
+      Date:
+      - Fri, 15 Apr 2016 13:13:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        [
+         {
+         "DOI": "10.1002/ECE3.563",
+         "RA": "CrossRef"
+        }
+        ]
+    http_version: 
+  recorded_at: Fri, 15 Apr 2016 13:13:13 GMT
+- request:
+    method: get
+    uri: http://doi.crossref.org/doiRA/10.1371/JOURNAL.PONE.0111985
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Lagotto - http://lagotto.local
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '66'
+      Date:
+      - Fri, 15 Apr 2016 13:13:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        [
+         {
+         "DOI": "10.1371/JOURNAL.PONE.0111985",
+         "RA": "CrossRef"
+        }
+        ]
+    http_version: 
+  recorded_at: Fri, 15 Apr 2016 13:13:14 GMT
+recorded_with: VCR 2.9.3

--- a/spec/models/agents/datacite_related_spec.rb
+++ b/spec/models/agents/datacite_related_spec.rb
@@ -105,6 +105,13 @@ describe DataciteRelated, type: :model, vcr: true do
                                           "registration_agency"=>"datacite",
                                           "tracked"=>true,
                                           "type"=>"dataset")
+
+      expect(response[1][:prefix]).to eq("10.5061")
+      expect(response[1][:relation]).to eq("subj_id"=>"http://doi.org/10.5061/DRYAD.47SD5",
+                                           "obj_id"=>"http://doi.org/10.1111/MEC.12069",
+                                           "relation_type_id"=>"is_referenced_by",
+                                           "source_id"=>"datacite_crossref",
+                                           "publisher_id"=>"CDL.DRYAD")
     end
 
     it "should catch timeout errors with the Datacite Metadata Search API" do


### PR DESCRIPTION
These names make it clearer that we are exchanging links across RAs. This will also help with filtering the data, e.g. in the admin UI or deposits API.

Also rewrote `datacite_related` agent to send to new `datacite_crossref` source_id if registration agency is Crossref.
