### PR TITLE
Add ability to put extra content in <head>

### DIFF
--- a/app/assets/stylesheets/crossref_event_data.css.scss
+++ b/app/assets/stylesheets/crossref_event_data.css.scss
@@ -55,11 +55,7 @@ h1, h2, h3, h4 {
 .crossref-logo {
 	margin: 15px;
 	width: 150px;
-<<<<<<< HEAD
 	height: 63px;
-=======
-	height: 125px;
->>>>>>> c865ae393146d01eb5e8f1342105a8e3497cf6d8
 }
 
 #sign-in {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
         data-apikey="<%= ENV['BUGSNAG_JS_KEY'] %>">
       </script>
     <% end %>
+    <%= render partial: "layouts/#{ENV['MODE']}/head" -%>
   </head>
 
   <body>

--- a/app/views/layouts/crossref_event_data/_footer.html.erb
+++ b/app/views/layouts/crossref_event_data/_footer.html.erb
@@ -1,0 +1,21 @@
+<script>
+$(document).ready(function () {
+  $.cookieCuttr({
+cookieDeclineButton: true
+});
+});      
+
+if (jQuery.cookie('cc_cookie_decline') == "cc_cookie_decline") {
+// do nothing 
+} else {
+var _gaq = _gaq || [];
+_gaq.push(['_setAccount', 'UA-11065739-13']);
+_gaq.push(['_trackPageview']);
+
+(function() {
+var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+var s = document. getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();
+}
+</script>

--- a/app/views/layouts/crossref_event_data/_head.html.erb
+++ b/app/views/layouts/crossref_event_data/_head.html.erb
@@ -1,0 +1,20 @@
+<link rel="apple-touch-icon" sizes="57x57" href="https://assets.crossref.org/favicon/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="https://assets.crossref.org/favicon/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="https://assets.crossref.org/favicon/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="https://assets.crossref.org/favicon/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="https://assets.crossref.org/favicon/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="https://assets.crossref.org/favicon/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="https://assets.crossref.org/favicon/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="https://assets.crossref.org/favicon/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="https://assets.crossref.org/favicon/apple-touch-icon-180x180.png">
+<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/android-chrome-192x192.png" sizes="192x192">
+<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/favicon-96x96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/favicon-16x16.png" sizes="16x16">
+<link rel="manifest" href="https://assets.crossref.org/favicon/manifest.json">
+<link rel="mask-icon" href="https://assets.crossref.org/favicon/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="apple-mobile-web-app-title" content="Crossref">
+<meta name="application-name" content="Crossref">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="msapplication-TileImage" content="https://assets.crossref.org/favicon/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">

--- a/app/views/layouts/crossref_event_data/_header.html.erb
+++ b/app/views/layouts/crossref_event_data/_header.html.erb
@@ -24,11 +24,7 @@
   <div class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="container-fluid">
       <div class="navbar-header">
-<<<<<<< HEAD
-        <a href="http://eventdata.crossref.org"><img src="http://assets.crossref.org/logo/crossref-event-data-logo-200.svg" alt="Crossref Event Data" class="crossref-logo"></a>
-=======
         <a href="http://eventdata.crossref.org"><img src="http://assets.crossref.org/logo/crossref-event-data-logo-200.svg" width="150" height="125" alt="Crossref Event Data" class="crossref-logo"></a>
->>>>>>> c865ae393146d01eb5e8f1342105a8e3497cf6d8
       </div>
       <div class="navbar-collapse collapse">
         <% unless ["sessions","registrations"].include?(controller.controller_name) %>

--- a/app/views/layouts/crossref_event_data/_header.html.erb
+++ b/app/views/layouts/crossref_event_data/_header.html.erb
@@ -1,25 +1,3 @@
-<link rel="apple-touch-icon" sizes="57x57" href="https://assets.crossref.org/favicon/apple-touch-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="https://assets.crossref.org/favicon/apple-touch-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="https://assets.crossref.org/favicon/apple-touch-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="https://assets.crossref.org/favicon/apple-touch-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="https://assets.crossref.org/favicon/apple-touch-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="https://assets.crossref.org/favicon/apple-touch-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="https://assets.crossref.org/favicon/apple-touch-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="https://assets.crossref.org/favicon/apple-touch-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="https://assets.crossref.org/favicon/apple-touch-icon-180x180.png">
-<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/android-chrome-192x192.png" sizes="192x192">
-<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/favicon-96x96.png" sizes="96x96">
-<link rel="icon" type="image/png" href="https://assets.crossref.org/favicon/favicon-16x16.png" sizes="16x16">
-<link rel="manifest" href="https://assets.crossref.org/favicon/manifest.json">
-<link rel="mask-icon" href="https://assets.crossref.org/favicon/safari-pinned-tab.svg" color="#5bbad5">
-<meta name="apple-mobile-web-app-title" content="Crossref">
-<meta name="application-name" content="Crossref">
-<meta name="msapplication-TileColor" content="#da532c">
-<meta name="msapplication-TileImage" content="https://assets.crossref.org/favicon/mstile-144x144.png">
-<meta name="theme-color" content="#ffffff">
-
-
 <div class="header" id="navtop">
   <div class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="container-fluid">

--- a/docs/crossref_event_data_index.md
+++ b/docs/crossref_event_data_index.md
@@ -3,11 +3,20 @@ layout: page
 title: "Crossref Event Data"
 ---
 
-# About Crossref Event Data
+# Early Preview: This service is under development.
 
-Much of the web activity around scholarly content happens outside of the formal literature. The scholarly community needs an infrastructure that collects, stores, and openly makes available these interactions. That’s why we at Crossref are [working to develop a new service](http://blog.crossref.org/2015/03/crossrefs-doi-event-tracker-pilot.html) that will provide a means of monitoring and displaying links to scholarly content on the open web.  Our belief is that the greater visibility provided by [Crossref Event Data](http://blog.crossref.org/2016/02/event-data-open-for-your-interpretation.html) will help publishers, authors, bibliometricians and libraries to develop a fuller understanding of where and how scholarly content is being shared and consumed.  
+This is a preview site to enable you to browse the Event Data that we’re collecting. We will be developing it into a full service.
 
+Please look around and explore our interim display of the raw data. At launch in the second half of 2016, we will provide formal mechanisms to view and access this data.
+
+Each publication in this system is displayed as a 'work.' Browse event data for the external platform of interest based on Source or Works. Event activity is displayed for each work in the Relations tab. The Results tab displays a summary visualization based on the date in which the system received the data.
+
+Please visit [eventdata.crossref.org](http://eventdata.crossref.org) for full information, including technical documentation or [contact us](mailto:eventdata@crossref.org) directly with your questions and feedback.  
+
+
+## About Crossref Event Data
+
+Much of the web activity around scholarly content happens outside of the formal literature. The scholarly community needs an infrastructure that collects, stores, and openly makes available these interactions. That’s why we at Crossref are [working to develop a new service](http://blog.crossref.org/category/event-data) that will provide a means of monitoring and displaying links to scholarly content on the open web.  Our belief is that the greater visibility provided by [Crossref Event Data](http://eventdata.crossref.org/) will help publishers, authors, bibliometricians and libraries to develop a fuller understanding of where and how scholarly content is being shared and consumed.  
 
 ## How it will work
-
 Crossref Event Data collects a wide variety of events related to any content with a DOI.  These events may include bookmarks, comments, social shares, citations, and links to other research entities. The Crossref Events Data service identifies and stores these events, and makes the data openly available so that anyone can see how the content is being shared. Importantly, publishers and vendors will be able to process and interpret the data for their own services. 


### PR DESCRIPTION
So that we can add a Crossref favicon, allow a `head.html.erb` template. Also added to default and DataCite. For #539 
