### PR TITLE
fix swagger documentation in deposits controller. Closes #549

### DIFF
--- a/app/controllers/api/v7/deposits_controller.rb
+++ b/app/controllers/api/v7/deposits_controller.rb
@@ -9,9 +9,11 @@ class Api::V7::DepositsController < Api::BaseController
   swagger_api :index do
     summary 'Returns all deposits, sorted by date'
     param :query, :message_type, :string, :optional, "Filter by message_type"
-    param :query, :state, :prefix, :optional, "Filter by DOI prefix"
     param :query, :source_token, :string, :optional, "Filter by source_token"
+    param :query, :source_id, :string, :optional, "Filter by source_id"
     param :query, :state, :string, :optional, "Filter by state"
+    param :query, :prefix, :string, :optional, "Filter by DOI prefix"
+    param :query, :q, :string, :optional, "Query for deposit UUID"
     response :ok
     response :unprocessable_entity
     response :not_found


### PR DESCRIPTION
Swagger documentation for `q` and `source_id` was missing, and it uses the wrong syntax for `prefix`.
