### PR TITLE
Prefixes as name

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -56,6 +56,7 @@ class Notification < ActiveRecord::Base
     report.send_fatal_error_report(message)
   end
 
+  # legacy support without any functionality
   def agent_id
     nil
   end

--- a/app/views/publishers/_index.html.erb
+++ b/app/views/publishers/_index.html.erb
@@ -21,7 +21,7 @@
             <div class="panel-heading"><%= publisher.title %></div>
             <div class="panel-body">
               <% if publisher.prefixes %>
-                <p><%= 'Prefix'.pluralize(publisher.prefixes.size) + ": " + publisher.prefixes.join(" ") %></p>
+                <p><%= 'Prefix'.pluralize(publisher.prefixes.size) + ": " + publisher.prefixes.map { |p| p.name }.join(" ") %></p>
               <% end %>
               <%= radio_button_tag "id", publisher.name, class: "radio_tag", tabindex: i %>Select
             </div>
@@ -65,7 +65,7 @@
             <div class="panel-body">
               <h4 class="work"><%= link_to h(publisher.title), publisher_path(publisher.name) %></h4>
               <% if publisher.prefixes.present? %>
-                <p><%= 'Prefix'.pluralize(publisher.prefixes.size) + ": " + publisher.prefixes.join(" ") %></p>
+                <p><%= 'Prefix'.pluralize(publisher.prefixes.size) + ": " + publisher.prefixes.map { |p| p.name }.join(" ") %></p>
               <% end %>
             </div>
             <div class="panel-footer">

--- a/app/views/publishers/_show.html.erb
+++ b/app/views/publishers/_show.html.erb
@@ -4,7 +4,7 @@
       <div class="panel-body">
         <h4 class="work"><%= @publisher.title.html_safe %></h4>
         <% if @publisher.prefixes %>
-          <div class="prefix"><%= 'Prefix'.pluralize(@publisher.prefixes.size) + ": " + @publisher.prefixes.join(" ") %></div>
+          <div class="prefix"><%= 'Prefix'.pluralize(@publisher.prefixes.size) + ": " + @publisher.prefixes.map { |p| p.name }.join(" ") %></div>
         <% end %>
         <% if can?(:read, Notification) && @publisher.users.present? %>
           <h5>Users</h5>


### PR DESCRIPTION
With the refactoring of prefixes in #558 the display of prefixes for publishers broke. This pull request fixes this.
