### PR TITLE
include publisher_id in contributions

### DIFF
--- a/app/controllers/api/v7/contributions_controller.rb
+++ b/app/controllers/api/v7/contributions_controller.rb
@@ -10,6 +10,7 @@ class Api::V7::ContributionsController < Api::BaseController
     summary "Returns list of works for a particular contributor"
     param :query, :contributor_role_id, :string, :optional, "Contributor_role ID"
     param :query, :source_id, :string, :optional, "Source ID"
+    param :query, :publisher_id, :string, :optional, "Publisher ID"
     param :query, :page, :integer, :optional, "Page number"
     param :query, :recent, :integer, :optional, "Limit to contributions created last x days"
     param :query, :per_page, :integer, :optional, "Results per page (0-1000), defaults to 1000"
@@ -36,6 +37,10 @@ class Api::V7::ContributionsController < Api::BaseController
 
     if params[:source_id] && source = Source.where(name: params[:source_id]).first
       collection = collection.where(source_id: source.id)
+    end
+
+    if params[:publisher_id] && publisher = Publisher.where(name: params[:publisher_id]).first
+      collection = collection.where(publisher_id: publisher.id)
     end
 
     if params[:recent]

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -89,6 +89,8 @@ class NotificationsController < ApplicationController
 
     collection = collection.query(params[:q]) if params[:q]
 
+    collection = collection.includes(:source, :work, :deposit)
+
     @levels = collection.where.not(level: nil).group(:level).count
     @hostnames = collection.where.not(hostname: nil).group(:hostname).count
     @class_names = collection.where.not(class_name: nil).group(:class_name).count

--- a/app/models/concerns/processable/contributor_processor.rb
+++ b/app/models/concerns/processable/contributor_processor.rb
@@ -21,8 +21,12 @@ module Processable
         return true unless obj_id.present?
 
         c = Contribution.where(contributor_id: contributor_id,
-                               work_id: related_work_id,
-                               source_id: source.present? ? source.id : nil).first_or_initialize
+                               work_id: related_work_id).first_or_initialize
+
+        # update all attributes
+        c.assign_attributes(source_id: source.present? ? source.id : nil,
+                            publisher_id: publisher.present? ? publisher.id : nil)
+
         c.save!
       rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => exception
         handle_exception(exception, class_name: "contribution", id: "#{subj_id}/#{obj_id}/#{source_id}")


### PR DESCRIPTION
This will make it easier to filter deposits and contributions by publisher.  In the case of DataCite the prefix doesn't always work as the prefix `10.1594` has been used by multiple organizations in the early days, and this is an important use case we need to cover.

Will need a more flexible way to filter deposits going forward.
