### PR TITLE
Fix to Facebook Agent and tests. For lagotto/lagotto#629

### DIFF
--- a/app/jobs/agent_job.rb
+++ b/app/jobs/agent_job.rb
@@ -13,6 +13,7 @@ class AgentJob < ActiveJob::Base
     retry_job wait: 5.minutes, queue: :default
   end
 
+  # This is queued by the queue.rake task.
   def perform(agent, options={})
     ActiveRecord::Base.connection_pool.with_connection do
       if options[:ids].present?

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -161,6 +161,8 @@ class Agent < ActiveRecord::Base
     end
   end
 
+  # Starting point for fetching a batch of data. Called by AgentJob.
+  # options should contain: work_id .
   def collect_data(options = {})
     data = get_data(options.merge(timeout: timeout, source_id: source_id))
 
@@ -176,12 +178,12 @@ class Agent < ActiveRecord::Base
     push_data(data, options)
   end
 
+  # Retrieve data from source API.
   def get_data(options={})
     query_url = get_query_url(options)
     return query_url.extend Hashie::Extensions::DeepFetch if query_url.is_a?(Hash)
 
     result = get_result(query_url, options.merge(request_options))
-
     # make sure we return a hash
     result = { 'data' => result } unless result.is_a?(Hash)
 

--- a/app/models/agents/facebook.rb
+++ b/app/models/agents/facebook.rb
@@ -39,9 +39,9 @@ class Facebook < Agent
     elsif url_linkstat.blank?
       readers, comments, likes = 0, 0, 0
     else
-      readers = result.deep_fetch('data', 0, 'share_count') { 0 }
-      comments = result.deep_fetch('data', 0, 'comment_count') { 0 }
-      likes = result.deep_fetch('data', 0, 'like_count') { 0 }
+      readers = result.deep_fetch('share', 0, 'share_count') { 0 }
+      comments = result.deep_fetch('share', 0, 'comment_count') { 0 }
+      likes = result.deep_fetch('share', 0, 'like_count') { 0 }
     end
 
     now = Date.new(current_year, current_month, 1)

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -31,7 +31,8 @@ namespace :queue do
 
   desc "Queue all works"
   task :all => :environment do |_, args|
-    if args.extras.empty?
+    # args can be string or nil hence `blank?`.
+    if args.extras.blank?
       agents = Agent.active
     else
       agents = Agent.active.where("name in (?)", args.extras)

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -353,8 +353,9 @@ FactoryGirl.define do
     type "Facebook"
     name "facebook"
     title "Facebook"
-    client_id ENV['FACEBOOK_CLIENT_ID']
-    client_secret ENV['FACEBOOK_CLIENT_SECRET']
+    client_id "FACEBOOK_CLIENT_ID"
+    client_secret "FACEBOOK_CLIENT_SECRET"
+
 
     group
 

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data/should_catch_authorization_errors_with_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data/should_catch_authorization_errors_with_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data/should_report_if_there_are_events_returned_by_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data/should_report_if_there_are_events_returned_by_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,12 +44,12 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:32 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.1/?access_token=<FACEBOOK_CLIENT_ID>%7CujiT_Cb58T4QUkneUYJu0L3zmwM&id=http://www.plosmedicine.org/article/info:doi/10.1371/journal.pmed.0020124
+    uri: https://graph.facebook.com/v2.1/?access_token=FACEBOOK_CLIENT_ID%7CujiT_Cb58T4QUkneUYJu0L3zmwM&id=http://www.plosmedicine.org/article/info:doi/10.1371/journal.pmed.0020124
     body:
       encoding: US-ASCII
       string: ''
@@ -59,7 +59,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer <FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      - Bearer FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data/should_report_if_there_are_no_events_returned_by_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data/should_report_if_there_are_no_events_returned_by_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,12 +44,12 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:36 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.1/?access_token=<FACEBOOK_CLIENT_ID>%7CujiT_Cb58T4QUkneUYJu0L3zmwM&id=http://www.plosone.org/article/info:doi/10.1371/journal.pone.0000001
+    uri: https://graph.facebook.com/v2.1/?access_token=FACEBOOK_CLIENT_ID%7CujiT_Cb58T4QUkneUYJu0L3zmwM&id=http://www.plosone.org/article/info:doi/10.1371/journal.pone.0000001
     body:
       encoding: US-ASCII
       string: ''
@@ -59,7 +59,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer <FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      - Bearer FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data/should_report_that_there_are_no_events_if_the_doi_and_canonical_URL_are_missing.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data/should_report_that_there_are_no_events_if_the_doi_and_canonical_URL_are_missing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:34 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_catch_authorization_errors_with_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_catch_authorization_errors_with_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -42,7 +42,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_catch_timeout_errors_with_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_catch_timeout_errors_with_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_report_if_there_are_events_returned_by_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_report_if_there_are_events_returned_by_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:31 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_report_if_there_are_no_events_returned_by_the_Facebook_API.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/get_data_with_url_linkstat/should_report_if_there_are_no_events_returned_by_the_Facebook_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:30 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/lookup_access_token/should_look_up_access_token_if_blank.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/lookup_access_token/should_look_up_access_token_if_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,12 +44,12 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:44:59 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.1/?access_token=<FACEBOOK_CLIENT_ID>%7CujiT_Cb58T4QUkneUYJu0L3zmwM&id=http://www.plosone.org/article/info:doi/10.1371/journal.pone.0043007
+    uri: https://graph.facebook.com/v2.1/?access_token=FACEBOOK_CLIENT_ID%7CujiT_Cb58T4QUkneUYJu0L3zmwM&id=http://www.plosone.org/article/info:doi/10.1371/journal.pone.0043007
     body:
       encoding: US-ASCII
       string: ''
@@ -59,7 +59,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer <FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      - Bearer FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr_cassettes/Facebook/lookup_access_token/should_make_the_right_API_call.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/lookup_access_token/should_make_the_right_API_call.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:42:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/lookup_canonical_URL/should_look_up_canonical_URL_if_there_is_no_work_url.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/lookup_canonical_URL/should_look_up_canonical_URL_if_there_is_no_work_url.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Facebook/lookup_canonical_URL/should_not_look_up_canonical_URL_if_there_is_work_url.yml
+++ b/spec/fixtures/vcr_cassettes/Facebook/lookup_canonical_URL/should_not_look_up_canonical_URL_if_there_is_work_url.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/oauth/access_token?client_id=<FACEBOOK_CLIENT_ID>&client_secret=<FACEBOOK_CLIENT_SECRET>&grant_type=client_credentials
+    uri: https://graph.facebook.com/oauth/access_token?client_id=FACEBOOK_CLIENT_ID&client_secret=FACEBOOK_CLIENT_SECRET&grant_type=client_credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
       - '57'
     body:
       encoding: UTF-8
-      string: access_token=<FACEBOOK_CLIENT_ID>|ujiT_Cb58T4QUkneUYJu0L3zmwM
+      string: access_token=FACEBOOK_CLIENT_ID|ujiT_Cb58T4QUkneUYJu0L3zmwM
     http_version: 
   recorded_at: Sat, 09 Apr 2016 13:49:38 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
- fix agent to parse the API response correctly
- change test fixtures to use FACEBOOK_CLIENT_SECRET and FACEBOOK_CLIENT_ID values
- fix 17 of 18 facebook tests
